### PR TITLE
Specific case cache functions

### DIFF
--- a/src/main/kotlin/net/pringles/kodi/gateway/cache/CacheConfig.kt
+++ b/src/main/kotlin/net/pringles/kodi/gateway/cache/CacheConfig.kt
@@ -1,35 +1,32 @@
 package net.pringles.kodi.gateway.cache
 
-import net.pringles.kodi.models.Guild
+import net.pringles.kodi.gateway.cache.modelCaches.*
 import net.pringles.kodi.models.Member
-import net.pringles.kodi.models.Role
-import net.pringles.kodi.models.User
-import net.pringles.kodi.models.channels.BaseChannel
 
 class CacheConfig(
-    var userCachePolicy: ModelCachePolicyBuilder<Long, User> = DefaultCachePolicy.user(),
-    var guildCachePolicy: ModelCachePolicyBuilder<Long, Guild> = DefaultCachePolicy.guild(),
-    var channelCachePolicy: ModelCachePolicyBuilder<Long, BaseChannel> = DefaultCachePolicy.channel(),
-    var roleCachePolicy: ModelCachePolicyBuilder<Long, Role> = DefaultCachePolicy.role(),
-    var memberCachePolicy: ModelCachePolicyBuilder<MemberCacheKey, Member> = DefaultCachePolicy.member(),
+    var userCachePolicy: UserCache = DefaultCachePolicy.user(),
+    var guildCachePolicy: GuildCache = DefaultCachePolicy.guild(),
+    var channelCachePolicy: ChannelCache = DefaultCachePolicy.channel(),
+    var roleCachePolicy: RoleCache = DefaultCachePolicy.role(),
+    var memberCachePolicy: MemberCache = DefaultCachePolicy.member(),
 ) {
-    fun user(builder: ModelCachePolicyBuilder<Long, User>.() -> Unit) {
-        userCachePolicy = ModelCachePolicyBuilder<Long, User>().apply(builder)
+    fun user(builder: UserCache.() -> Unit) {
+        userCachePolicy = UserCache().apply(builder)
     }
 
-    fun guild(builder: ModelCachePolicyBuilder<Long, Guild>.() -> Unit) {
-        guildCachePolicy = ModelCachePolicyBuilder<Long, Guild>().apply(builder)
+    fun guild(builder: GuildCache.() -> Unit) {
+        guildCachePolicy = GuildCache().apply(builder)
     }
 
-    fun channel(builder: ModelCachePolicyBuilder<Long, BaseChannel>.() -> Unit) {
-        channelCachePolicy = ModelCachePolicyBuilder<Long, BaseChannel>().apply(builder)
+    fun channel(builder: ChannelCache.() -> Unit) {
+        channelCachePolicy = ChannelCache().apply(builder)
     }
 
-    fun role(builder: ModelCachePolicyBuilder<Long, Role>.() -> Unit) {
-        roleCachePolicy = ModelCachePolicyBuilder<Long, Role>().apply(builder)
+    fun role(builder: RoleCache.() -> Unit) {
+        roleCachePolicy = RoleCache().apply(builder)
     }
 
     fun member(builder: ModelCachePolicyBuilder<MemberCacheKey, Member>.() -> Unit) {
-        memberCachePolicy = ModelCachePolicyBuilder<MemberCacheKey, Member>().apply(builder)
+        memberCachePolicy = MemberCache().apply(builder)
     }
 }

--- a/src/main/kotlin/net/pringles/kodi/gateway/cache/DefaultCachePolicy.kt
+++ b/src/main/kotlin/net/pringles/kodi/gateway/cache/DefaultCachePolicy.kt
@@ -1,5 +1,6 @@
 package net.pringles.kodi.gateway.cache
 
+import net.pringles.kodi.gateway.cache.modelCaches.*
 import net.pringles.kodi.models.Guild
 import net.pringles.kodi.models.Member
 import net.pringles.kodi.models.Role
@@ -15,7 +16,7 @@ object DefaultCachePolicy {
     private val memberCache = ConcurrentHashMap<MemberCacheKey, Member>()
 
     fun user() =
-        ModelCachePolicyBuilder<Long, User>().apply {
+        UserCache().apply {
             view { userCache.values.toList() }
             get { userCache[it] }
             update { userCache[it.id] = it }
@@ -23,7 +24,7 @@ object DefaultCachePolicy {
         }
 
     fun guild() =
-        ModelCachePolicyBuilder<Long, Guild>().apply {
+        GuildCache().apply {
             view { guildCache.values.toList() }
             get { id -> guildCache[id] }
             update { guild -> guildCache[guild.id] = guild }
@@ -31,7 +32,7 @@ object DefaultCachePolicy {
         }
 
     fun channel() =
-        ModelCachePolicyBuilder<Long, BaseChannel>().apply {
+        ChannelCache().apply {
             view { channelCache.values.toList() }
             get { id -> channelCache[id] }
             update { channel -> channelCache[channel.id] = channel }
@@ -39,7 +40,7 @@ object DefaultCachePolicy {
         }
 
     fun role() =
-        ModelCachePolicyBuilder<Long, Role>().apply {
+        RoleCache().apply {
             view { roleCache.values.toList() }
             get { id -> roleCache[id] }
             update { role -> roleCache[role.id] = role }
@@ -47,12 +48,12 @@ object DefaultCachePolicy {
         }
 
     fun member() =
-        ModelCachePolicyBuilder<MemberCacheKey, Member>().apply {
+        MemberCache().apply {
             view { memberCache.values.toList() }
             get { memberCache[it] }
             update { memberCache[MemberCacheKey(it.guildId, it.id)] = it }
             remove { memberCache.remove(it) }
         }
 
-    fun <K, V> none() = ModelCachePolicyBuilder<K, V>()
+    fun <K, V> none() = EmptyCache<K, V>()
 }

--- a/src/main/kotlin/net/pringles/kodi/gateway/cache/ModelCachePolicyBuilder.kt
+++ b/src/main/kotlin/net/pringles/kodi/gateway/cache/ModelCachePolicyBuilder.kt
@@ -7,7 +7,7 @@ typealias GetCache<K, V> = suspend (K) -> V?
 typealias UpdateCache<V> = suspend (V) -> Unit
 typealias RemoveCache<K> = suspend (K) -> Unit
 
-class ModelCachePolicyBuilder<K, V>(
+abstract class ModelCachePolicyBuilder<K, V>(
     internal var onView: ViewCache<V>? = null,
     internal var onGet: GetCache<K, V>? = null,
     internal var onUpdate: UpdateCache<V>? = null,

--- a/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/ChannelCache.kt
+++ b/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/ChannelCache.kt
@@ -1,0 +1,6 @@
+package net.pringles.kodi.gateway.cache.modelCaches
+
+import net.pringles.kodi.gateway.cache.ModelCachePolicyBuilder
+import net.pringles.kodi.models.channels.BaseChannel
+
+class ChannelCache : ModelCachePolicyBuilder<Long, BaseChannel>()

--- a/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/EmptyCache.kt
+++ b/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/EmptyCache.kt
@@ -1,0 +1,5 @@
+package net.pringles.kodi.gateway.cache.modelCaches
+
+import net.pringles.kodi.gateway.cache.ModelCachePolicyBuilder
+
+class EmptyCache<K, V> : ModelCachePolicyBuilder<K, V>()

--- a/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/GuildCache.kt
+++ b/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/GuildCache.kt
@@ -1,0 +1,6 @@
+package net.pringles.kodi.gateway.cache.modelCaches
+
+import net.pringles.kodi.gateway.cache.ModelCachePolicyBuilder
+import net.pringles.kodi.models.Guild
+
+class GuildCache : ModelCachePolicyBuilder<Long, Guild>()

--- a/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/MemberCache.kt
+++ b/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/MemberCache.kt
@@ -1,0 +1,7 @@
+package net.pringles.kodi.gateway.cache.modelCaches
+
+import net.pringles.kodi.gateway.cache.MemberCacheKey
+import net.pringles.kodi.gateway.cache.ModelCachePolicyBuilder
+import net.pringles.kodi.models.Member
+
+class MemberCache : ModelCachePolicyBuilder<MemberCacheKey, Member>()

--- a/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/RoleCache.kt
+++ b/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/RoleCache.kt
@@ -1,0 +1,15 @@
+package net.pringles.kodi.gateway.cache.modelCaches
+
+import net.pringles.kodi.gateway.cache.ModelCachePolicyBuilder
+import net.pringles.kodi.models.Role
+
+class RoleCache(
+    internal var onGetByGuildId: ((Long) -> List<Role>)? = null
+) : ModelCachePolicyBuilder<Long, Role>() {
+
+
+    fun getByGuildId(action: (Long) -> List<Role>) {
+        onGetByGuildId = action
+    }
+
+}

--- a/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/UserCache.kt
+++ b/src/main/kotlin/net/pringles/kodi/gateway/cache/modelCaches/UserCache.kt
@@ -1,0 +1,6 @@
+package net.pringles.kodi.gateway.cache.modelCaches
+
+import net.pringles.kodi.gateway.cache.ModelCachePolicyBuilder
+import net.pringles.kodi.models.User
+
+class UserCache : ModelCachePolicyBuilder<Long, User>()

--- a/src/test/kotlin/net/pringles/kodi/test.kt
+++ b/src/test/kotlin/net/pringles/kodi/test.kt
@@ -25,6 +25,9 @@ fun main() = runBlocking {
                 get { roleCache[it] }
                 update { if (it.id == it.guildId) roleCache[it.id] = it }
                 remove { roleCache.remove(it) }
+                getByGuildId {
+                    emptyList()
+                }
             }
         }
     }


### PR DESCRIPTION
I was still stuck at building each cache. I wanted to try some sort of builder but for this we would need 2 classes nearly identical except one has a `KodiClient` as parameter. Not sure if this is something optimal. At least to me this idea looked odd.
Maybe we can build each cache with a lateinit client or so?

So here will be the to-do
- [ ] Make cache accessible with cache specific class, not superclass
- [ ] Naming things nicer
- [ ] Implementing special case functions (like `getByGuildId`) for other caches